### PR TITLE
Automatically detect League client folder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'colorize', '~> 0.8.1'
 gem 'json', '~> 2.6'
 gem 'launchy', '~> 2.5'
 gem 'open-uri', '~> 0.2.0'
+gem 'win32-shortcut', '~> 0.3.0'
 
 group :development do
   # Builds windows executable

--- a/disenchanter.rb
+++ b/disenchanter.rb
@@ -195,9 +195,15 @@ def read_lockfile
     end
   end
   if lockfile == "lockfile"
-    puts "Failed to automatically get League path. Please place the script in your League Client folder.".light_red
+    begin
+      contents = File.read("C:\\Riot Games\\League of Legends\\" + lockfile)
+    rescue => exception
+      puts "Failed to automatically get League path. Please place the script in your League Client folder.".light_red
+      contents = File.read(lockfile) 
+    end
+  else
+    contents = File.read(lockfile) 
   end
-  contents = File.read(lockfile)
   _leagueclient, _unk_port, port, password = contents.split(":")
   token = Base64.encode64("riot:#{password.chomp}")
 

--- a/disenchanter.rb
+++ b/disenchanter.rb
@@ -172,7 +172,7 @@ def read_lockfile
   if is_windows == 0
     puts "Trying to automatically get the path of the League Client".green
     begin
-      keeyname = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Riot Game league_of_legends.live"
+      keyname = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Riot Game league_of_legends.live"
       reg = Win32::Registry::HKEY_CURRENT_USER.open(keyname,
         Win32::Registry::KEY_READ | Win32::Registry::KEY_WOW64_32KEY)
         lockfile = reg['InstallLocation'] + "/lockfile"

--- a/disenchanter.rb
+++ b/disenchanter.rb
@@ -8,7 +8,7 @@ require "colorize"
 require "launchy"
 require "open-uri"
 require 'rbconfig'
-require 'Win32' if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+require 'win32/registry' if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
 
 if (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
   module Win32::Registry::Constants

--- a/disenchanter.rb
+++ b/disenchanter.rb
@@ -8,7 +8,7 @@ require "colorize"
 require "launchy"
 require "open-uri"
 require 'rbconfig'
-require 'win32/registry' if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+require 'Win32' if RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
 
 if (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
   module Win32::Registry::Constants


### PR DESCRIPTION
Automatically detect League Client folder using the installation registry key. If the registry key does not exist, the start menu shortcut is used. If both methods fail, the script checks if the default path is used. If everything fails, the script has to be placed in the league client folder like usually.